### PR TITLE
Feat/8/define model

### DIFF
--- a/backend/mirisira_api/admin.py
+++ b/backend/mirisira_api/admin.py
@@ -1,3 +1,12 @@
 from django.contrib import admin
 
 # Register your models here.
+
+from .models import *
+
+admin.site.register(Question)
+admin.site.register(Picture)
+admin.site.register(Answer)
+admin.site.register(OneCharacterAnswer)
+
+#TODO: update admin site like https://docs.djangoproject.com/ja/4.0/intro/tutorial07/

--- a/backend/mirisira_api/admin.py
+++ b/backend/mirisira_api/admin.py
@@ -1,12 +1,27 @@
+from email.errors import ObsoleteHeaderDefect
 from django.contrib import admin
 
 # Register your models here.
 
 from .models import *
 
-admin.site.register(Question)
+class PictureInline(admin.StackedInline):
+    model = Picture
+    extra = 5
+
+class QuestionAdmin(admin.ModelAdmin):
+    inlines = [PictureInline]
+
+class OneCharacterAnswerInline(admin.StackedInline):
+    model = OneCharacterAnswer
+    extra = 5
+
+class AnswerAdmin(admin.ModelAdmin):
+    inlines = [OneCharacterAnswerInline]
+
+admin.site.register(Question, QuestionAdmin)
 admin.site.register(Picture)
-admin.site.register(Answer)
+admin.site.register(Answer, AnswerAdmin)
 admin.site.register(OneCharacterAnswer)
 
 #TODO: update admin site like https://docs.djangoproject.com/ja/4.0/intro/tutorial07/

--- a/backend/mirisira_api/models.py
+++ b/backend/mirisira_api/models.py
@@ -1,4 +1,3 @@
-from xml.etree.ElementTree import PI
 from django.db import models
 
 # Create your models here.

--- a/backend/mirisira_api/models.py
+++ b/backend/mirisira_api/models.py
@@ -11,7 +11,7 @@ class Question(models.Model):
 
 class Picture(models.Model):
     question = models.ForeignKey(Question, on_delete=models.CASCADE)
-    file_path = models.CharField(max_length=255) # TODO:survey
+    file_path = models.CharField(max_length=255) # TODO: survey how to save pictures
 
 
 class Answer(models.Model):

--- a/backend/mirisira_api/models.py
+++ b/backend/mirisira_api/models.py
@@ -3,16 +3,22 @@ from django.db import models
 # Create your models here.
 
 
-class Target(models.Model):
-    name = models.CharField(max_length=32)
-    picture = models.CharField(max_length=200, null=True)  # TODO: 仮のフィールド
 
 
-class Question(models.Model):
-    target = models.ForeignKey(Target, on_delete=models.CASCADE)
-    question_text = models.CharField(max_length=200)
 
 
-class Answer(models.Model):
-    question = models.ForeignKey(Question, on_delete=models.CASCADE)
-    answer_text = models.CharField(max_length=200)
+
+# feat/2/define-model
+# class Target(models.Model):
+    # name = models.CharField(max_length=32)
+    # picture = models.CharField(max_length=200, null=True)  # TODO: 仮のフィールド
+
+
+# class Question(models.Model):
+    # target = models.ForeignKey(Target, on_delete=models.CASCADE)
+    # question_text = models.CharField(max_length=200)
+
+
+# class Answer(models.Model):
+    # question = models.ForeignKey(Question, on_delete=models.CASCADE)
+    # answer_text = models.CharField(max_length=200)

--- a/backend/mirisira_api/models.py
+++ b/backend/mirisira_api/models.py
@@ -1,11 +1,30 @@
+from xml.etree.ElementTree import PI
 from django.db import models
 
 # Create your models here.
 
+class Question(models.Model):
+    title = models.CharField(max_length=31)
+    creator_name = models.CharField(max_length=31)
+    create_at = models.DateTimeField(auto_now_add=True)
 
 
+class Picture(models.Model):
+    question = models.ForeignKey(Question, on_delete=models.CASCADE)
+    file_path = models.CharField(max_length=255) # TODO:survey
 
 
+class Answer(models.Model):
+    question = models.ForeignKey(Question, on_delete=models.CASCADE)
+    answerer_name = models.CharField(max_length=31)
+    create_at = models.DateTimeField(auto_now_add=True)
+
+
+class OneCharacterAnswer(models.Model):
+    picture = models.ForeignKey(Picture, on_delete=models.CASCADE)
+    answer = models.ForeignKey(Answer, on_delete=models.CASCADE)
+    character_name = models.CharField(max_length=31)
+    character_explanation = models.TextField()
 
 
 # feat/2/define-model

--- a/backend/mirisira_api/serializers.py
+++ b/backend/mirisira_api/serializers.py
@@ -1,28 +1,35 @@
 from dataclasses import field
 from rest_framework import serializers
 
-from .models import Target, Question, Answer
 
 
-class TargetSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Target
-        fields = ["id", "name", "picture"]
 
 
-class QuestionSerializer(serializers.ModelSerializer):
-    target_id = serializers.IntegerField()
-    question = serializers.CharField(source="question_text")
-
-    class Meta:
-        model = Question
-        fields = ["id", "target_id", "question"]
 
 
-class AnswerSerializer(serializers.ModelSerializer):
-    question_id = serializers.IntegerField()
-    answer = serializers.CharField(source="answer_text")
 
-    class Meta:
-        model = Answer
-        fields = ["id", "question_id", "answer"]
+
+
+# feat/2/define-model
+# from .models import Target, Question, Answer
+
+# class TargetSerializer(serializers.ModelSerializer):
+    # class Meta:
+        # model = Target
+        # fields = ["id", "name", "picture"]
+
+# class QuestionSerializer(serializers.ModelSerializer):
+    # target_id = serializers.IntegerField()
+    # question = serializers.CharField(source="question_text")
+
+    # class Meta:
+        # model = Question
+        # fields = ["id", "target_id", "question"]
+
+# class AnswerSerializer(serializers.ModelSerializer):
+    # question_id = serializers.IntegerField()
+    # answer = serializers.CharField(source="answer_text")
+
+    # class Meta:
+        # model = Answer
+        # fields = ["id", "question_id", "answer"]

--- a/backend/mirisira_api/serializers/__init__.py
+++ b/backend/mirisira_api/serializers/__init__.py
@@ -1,0 +1,2 @@
+from .question_serializers import *
+from .answer_serializers import *

--- a/backend/mirisira_api/serializers/answer_serializers.py
+++ b/backend/mirisira_api/serializers/answer_serializers.py
@@ -1,0 +1,8 @@
+# for answer serializer
+
+from dataclasses import field
+from rest_framework import serializers
+
+# from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
+
+# class Hoge(serializers.ModelSerializer):

--- a/backend/mirisira_api/serializers/old_serializers.py
+++ b/backend/mirisira_api/serializers/old_serializers.py
@@ -1,22 +1,16 @@
-from dataclasses import field
-from rest_framework import serializers
-
-
-
-
-
-
-
-
-
-
 # feat/2/define-model
+
+# from dataclasses import field
+# from rest_framework import serializers
+
 # from .models import Target, Question, Answer
+
 
 # class TargetSerializer(serializers.ModelSerializer):
     # class Meta:
         # model = Target
         # fields = ["id", "name", "picture"]
+
 
 # class QuestionSerializer(serializers.ModelSerializer):
     # target_id = serializers.IntegerField()
@@ -25,6 +19,7 @@ from rest_framework import serializers
     # class Meta:
         # model = Question
         # fields = ["id", "target_id", "question"]
+
 
 # class AnswerSerializer(serializers.ModelSerializer):
     # question_id = serializers.IntegerField()

--- a/backend/mirisira_api/serializers/question_serializers.py
+++ b/backend/mirisira_api/serializers/question_serializers.py
@@ -1,0 +1,8 @@
+# for question serializer
+
+from dataclasses import field
+from rest_framework import serializers
+
+# from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
+
+# class Hoge(serializers.ModelSerializer):

--- a/backend/mirisira_api/urls.py
+++ b/backend/mirisira_api/urls.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import url
 
-from mirisira_api.views import *
+from mirisira_api.views.question_views import *
+from mirisira_api.views.answer_views import *
 
 urlpatterns = [
-    url('test/', APITestView.as_view()),
+    url(r'^test/$', APITestView.as_view()),
+
+    #TODO: add url patterns from each view
+
 
     # feat/2/define-model
     # url('targets/', TargetList.as_view()),

--- a/backend/mirisira_api/urls.py
+++ b/backend/mirisira_api/urls.py
@@ -5,7 +5,9 @@ from mirisira_api.views import *
 
 urlpatterns = [
     url('test/', APITestView.as_view()),
-    url('targets/', TargetList.as_view()),
-    url('questions/', QuestionList.as_view()),
-    url('answers/', AnswerList.as_view()),
+
+    # feat/2/define-model
+    # url('targets/', TargetList.as_view()),
+    # url('questions/', QuestionList.as_view()),
+    # url('answers/', AnswerList.as_view()),
 ]

--- a/backend/mirisira_api/views.py
+++ b/backend/mirisira_api/views.py
@@ -3,39 +3,41 @@ from django.http import JsonResponse
 from rest_framework import generics, status
 from rest_framework.response import Response
 
-from .models import Target, Question, Answer
-from .serializers import TargetSerializer, QuestionSerializer, AnswerSerializer
 
 
-class APITestView(APIView):
-    def get(self, request, **kwargs):
-        return JsonResponse({"data": "get request"})
 
 
-class TargetList(generics.ListAPIView):
-    queryset = Target.objects.all()
-    serializer_class = TargetSerializer
 
+# feat/2/define-model
+# from .models import Target, Question, Answer
+# from .serializers import TargetSerializer, QuestionSerializer, AnswerSerializer
 
-class QuestionList(generics.ListAPIView):
-    serializer_class = QuestionSerializer
+# class APITestView(APIView):
+    # def get(self, request, **kwargs):
+        # return JsonResponse({"data": "get request"})
 
-    def get_queryset(self):
-        target_id = self.request.query_params["id"]
-        return Question.objects.filter(target_id=target_id)
+# class TargetList(generics.ListAPIView):
+    # queryset = Target.objects.all()
+    # serializer_class = TargetSerializer
 
+# class QuestionList(generics.ListAPIView):
+    # serializer_class = QuestionSerializer
 
-class AnswerList(generics.ListCreateAPIView):
-    serializer_class = AnswerSerializer
+    # def get_queryset(self):
+        # target_id = self.request.query_params["id"]
+        # return Question.objects.filter(target_id=target_id)
 
-    def get_queryset(self):
-        question_id = self.request.query_params["question_id"]
-        return Answer.objects.filter(question_id=question_id)
+# class AnswerList(generics.ListCreateAPIView):
+    # serializer_class = AnswerSerializer
 
-    def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(
-            data=request.data["QAList"], many=True)
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+    # def get_queryset(self):
+        # question_id = self.request.query_params["question_id"]
+        # return Answer.objects.filter(question_id=question_id)
+
+    # def create(self, request, *args, **kwargs):
+        # serializer = self.get_serializer(
+            # data=request.data["QAList"], many=True)
+        # serializer.is_valid(raise_exception=True)
+        # self.perform_create(serializer)
+        # headers = self.get_success_headers(serializer.data)
+        # return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/backend/mirisira_api/views/__init__.py
+++ b/backend/mirisira_api/views/__init__.py
@@ -1,0 +1,2 @@
+from .question_views import *
+from .answer_views import *

--- a/backend/mirisira_api/views/answer_views.py
+++ b/backend/mirisira_api/views/answer_views.py
@@ -1,0 +1,11 @@
+# for answer view
+
+from rest_framework.views import APIView
+from django.http import JsonResponse
+from rest_framework import generics, status
+from rest_framework.response import Response
+
+# from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
+# from mirisira_api.serializers.answer_serializers import *
+
+# class Fuga(piyo):

--- a/backend/mirisira_api/views/old_views.py
+++ b/backend/mirisira_api/views/old_views.py
@@ -1,24 +1,23 @@
-from rest_framework.views import APIView
-from django.http import JsonResponse
-from rest_framework import generics, status
-from rest_framework.response import Response
-
-
-
-
-
-
 # feat/2/define-model
+
+# from rest_framework.views import APIView
+# from django.http import JsonResponse
+# from rest_framework import generics, status
+# from rest_framework.response import Response
+
 # from .models import Target, Question, Answer
 # from .serializers import TargetSerializer, QuestionSerializer, AnswerSerializer
+
 
 # class APITestView(APIView):
     # def get(self, request, **kwargs):
         # return JsonResponse({"data": "get request"})
 
+
 # class TargetList(generics.ListAPIView):
     # queryset = Target.objects.all()
     # serializer_class = TargetSerializer
+
 
 # class QuestionList(generics.ListAPIView):
     # serializer_class = QuestionSerializer
@@ -26,6 +25,7 @@ from rest_framework.response import Response
     # def get_queryset(self):
         # target_id = self.request.query_params["id"]
         # return Question.objects.filter(target_id=target_id)
+
 
 # class AnswerList(generics.ListCreateAPIView):
     # serializer_class = AnswerSerializer

--- a/backend/mirisira_api/views/question_views.py
+++ b/backend/mirisira_api/views/question_views.py
@@ -1,0 +1,11 @@
+# for question view
+
+from rest_framework.views import APIView
+from django.http import JsonResponse
+from rest_framework import generics, status
+from rest_framework.response import Response
+
+# from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
+# from mirisira_api.serializers.question_serializers import *
+
+# class Fuga(piyo):

--- a/backend/mirisira_api/views/question_views.py
+++ b/backend/mirisira_api/views/question_views.py
@@ -8,4 +8,8 @@ from rest_framework.response import Response
 # from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
 # from mirisira_api.serializers.question_serializers import *
 
+class APITestView(APIView):
+    def get(self, request, **kwargs):
+        return JsonResponse({"data": "get request"})
+
 # class Fuga(piyo):


### PR DESCRIPTION
#8 のreviewお願いします．

# 変更箇所
- 先週の小野さん実装分をコメントアウト
- models.pyにモデル定義
- serializersとviewsのディレクトリを作成し，その中でquestionとanswerを分離
- adminページの作成

# 引き継ぎ事項
- serializersとviewsは，一応該当ファイルを作っておいたので，追記いただけると良いかなと思います．
- viewsまで完成したらurl.pyのurlpatternをいじる必要があります．参考 : https://qiita.com/RyoMa_0923/items/c4ca5bd070e823403fdf 
- adminサイトはほぼデフォルトなのであまり綺麗じゃなさそうです．今はエラーが出るので確認できませんでした．動くようになってから少し工夫したいところです… 参考 : https://docs.djangoproject.com/ja/4.0/intro/tutorial07/ 

よろしくお願いします