### PR TITLE
feat: answer周りのSerializer, Viewの作成

### DIFF
--- a/backend/api-document.yaml
+++ b/backend/api-document.yaml
@@ -162,6 +162,9 @@ components:
     AnswersPostRequest:
       type: object
       properties:
+        question_id:
+          type: integer
+          description: 質問ID
         characters:
           type: array
           items:

--- a/backend/mirisira_api/models.py
+++ b/backend/mirisira_api/models.py
@@ -21,7 +21,8 @@ class Answer(models.Model):
 
 class OneCharacterAnswer(models.Model):
     picture = models.ForeignKey(Picture, on_delete=models.CASCADE)
-    answer = models.ForeignKey(Answer, on_delete=models.CASCADE)
+    answer = models.ForeignKey(
+        Answer, related_name="characters", on_delete=models.CASCADE)
     character_name = models.CharField(max_length=31)
     character_explanation = models.TextField()
 

--- a/backend/mirisira_api/serializers/answer_serializers.py
+++ b/backend/mirisira_api/serializers/answer_serializers.py
@@ -3,6 +3,47 @@
 from dataclasses import field
 from rest_framework import serializers
 
-# from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
+from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
 
 # class Hoge(serializers.ModelSerializer):
+
+
+class OneCharacterAnswerSerializer(serializers.ModelSerializer):
+    picture_id = serializers.IntegerField()
+
+    class Meta:
+        model = OneCharacterAnswer
+        fields = ["picture_id", "character_name", "character_explanation"]
+
+
+class AnswerSerializer(serializers.ModelSerializer):
+    characters = OneCharacterAnswerSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Answer
+        fields = ["characters"]
+
+
+class AnswerGetSerializer(serializers.ModelSerializer):
+    answer_id = serializers.IntegerField(source="id", read_only=True)
+
+    class Meta:
+        model = Answer
+        fields = ["answer_id", "answerer_name", "create_at"]
+
+
+class AnswerPostSerializer(serializers.ModelSerializer):
+    question_id = serializers.IntegerField()
+    characters = OneCharacterAnswerSerializer(many=True)
+
+    class Meta:
+        model = Answer
+        fields = ["question_id", "answerer_name", "characters"]
+
+    def create(self, validated_data):
+        one_character_answers_data = validated_data.pop("characters")
+        answer = Answer.objects.create(**validated_data)
+        for one_character_answer in one_character_answers_data:
+            OneCharacterAnswer.objects.create(
+                answer=answer, **one_character_answer)
+        return answer

--- a/backend/mirisira_api/serializers/answer_serializers.py
+++ b/backend/mirisira_api/serializers/answer_serializers.py
@@ -1,11 +1,8 @@
 # for answer serializer
 
-from dataclasses import field
 from rest_framework import serializers
 
-from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
-
-# class Hoge(serializers.ModelSerializer):
+from mirisira_api.models import Answer, OneCharacterAnswer
 
 
 class OneCharacterAnswerSerializer(serializers.ModelSerializer):

--- a/backend/mirisira_api/urls.py
+++ b/backend/mirisira_api/urls.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import url
+from django.urls import path
 
 from mirisira_api.views.question_views import *
 from mirisira_api.views.answer_views import *
@@ -13,5 +14,6 @@ urlpatterns = [
     # feat/2/define-model
     # url('targets/', TargetList.as_view()),
     # url('questions/', QuestionList.as_view()),
-    # url('answers/', AnswerList.as_view()),
+    path('answers/', AnswerList.as_view()),
+    path('answers/<int:pk>/', AnswerRetrieve.as_view()),
 ]

--- a/backend/mirisira_api/views/answer_views.py
+++ b/backend/mirisira_api/views/answer_views.py
@@ -1,14 +1,10 @@
 # for answer view
 
-from rest_framework.views import APIView
-from django.http import JsonResponse
-from rest_framework import generics, status
+from rest_framework import generics
 from rest_framework.response import Response
 
-from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
+from mirisira_api.models import Answer
 from mirisira_api.serializers.answer_serializers import AnswerSerializer, AnswerGetSerializer, AnswerPostSerializer
-
-# class Fuga(piyo):
 
 
 class AnswerList(generics.ListCreateAPIView):

--- a/backend/mirisira_api/views/answer_views.py
+++ b/backend/mirisira_api/views/answer_views.py
@@ -5,7 +5,34 @@ from django.http import JsonResponse
 from rest_framework import generics, status
 from rest_framework.response import Response
 
-# from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
-# from mirisira_api.serializers.answer_serializers import *
+from mirisira_api.models import Question, Picture, Answer, OneCharacterAnswer
+from mirisira_api.serializers.answer_serializers import AnswerSerializer, AnswerGetSerializer, AnswerPostSerializer
 
 # class Fuga(piyo):
+
+
+class AnswerList(generics.ListCreateAPIView):
+    def get_queryset(self):
+        question_id = self.request.query_params["question_id"]
+        return Answer.objects.filter(question_id=question_id)
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return AnswerGetSerializer
+        return AnswerPostSerializer
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response({"answers": serializer.data})
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response({"answers": serializer.data})
+
+
+class AnswerRetrieve(generics.RetrieveAPIView):
+    queryset = Answer.objects.all()
+    serializer_class = AnswerSerializer


### PR DESCRIPTION
issue #10

## 変更箇所

* Answer関連のViewおよび必要なSerializerを作成
* OneCharacterAnswerモデルのフィールドを一部変更
  * Serializer内で[Nested relationships](https://www.django-rest-framework.org/api-guide/relations/#nested-relationships)を定義するため
* /answer/へのPOSTにquestion_idを含めるようにAPIを変更
  * OneCharacterAnswerをDBに追加する際に必要であるため