### PR TITLE
chore: CORSの設定

### DIFF
--- a/backend/mirisira_platform/settings.py
+++ b/backend/mirisira_platform/settings.py
@@ -111,7 +111,12 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 CORS_ORIGIN_WHITELIST = [
-    'http://127.0.0.1:3000'
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:3030',
+    'http://127.0.0.1:3333',
+    'http://localhost:3000',
+    'http://localhost:3030',
+    'http://localhost:3333',
 ]
 
 # Internationalization


### PR DESCRIPTION
issue #23

`mirisira_platform/settings.py` の `CORS_ORIGIN_WHITELIST` にフロントエンド，slackのポート番号を追加した．